### PR TITLE
Thunene visibility bug

### DIFF
--- a/web/client/components/TOC/DefaultGroup.jsx
+++ b/web/client/components/TOC/DefaultGroup.jsx
@@ -68,6 +68,14 @@ class DefaultGroup extends React.Component {
     };
 
     renderVisibility = (error) => {
+        const node = this.props.node 
+        if ( node && node.nodes) {
+            node.nodes.forEach((subnode) => {
+                if (subnode.visibility) {
+                    node.visibility = true;
+                }
+            });
+        }
         return this.props.groupVisibilityCheckbox && !error ?
             (<VisibilityCheck
                 node={this.props.node}

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -462,7 +462,8 @@ export const splitMapAndLayers = (mapState) => {
                         title: group.title,
                         description: group.description,
                         tooltipOptions: group.tooltipOptions,
-                        tooltipPlacement: group.tooltipPlacement
+                        tooltipPlacement: group.tooltipPlacement,
+                        exclusiveLayer: group.exclusiveLayer
                     };
                     newGroups = LayersUtils.deepChange(newGroups, group.id, groupMetadata);
                 }

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -470,7 +470,8 @@ export const groupSaveFormatted = (node) => {
         description: node.description,
         tooltipOptions: node.tooltipOptions,
         tooltipPlacement: node.tooltipPlacement,
-        expanded: node.expanded
+        expanded: node.expanded,
+        exclusiveLayer: node.exclusiveLayer
     };
 };
 


### PR DESCRIPTION
 address visibility bug on group level. Eye should be open if at least one subnode is open. Creates some errors (see console), but I couldn't find out if these errors cause any problems.